### PR TITLE
Changed fabric.mod.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# carpet-autoCraftingTable
-autoCraftingTable extension for carpet-mod. Implementation based on Skyrising's implementation for autoCraftingTable for QuickCarpet - implemnted here as an extension for fabric-carpet mod.
+# Carpet AutoCraftingTable - Unofficial Fork
+
+### IF YOU WANT THE MOD, GO HERE: https://github.com/gnembon/carpet-autoCraftingTable
+THIS IS A FORK OF CARPET AUTOCRAFTINGTABLE FOR MY TESTING PURPOSES. DO NOT USE THIS FORK. I HAVE ABSOLUTELY NO IDEA WHAT I AM DOING SO DON'T LOOK TO ME.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
-# Carpet AutoCraftingTable - Unofficial Fork
-
-### IF YOU WANT THE MOD, GO HERE: https://github.com/gnembon/carpet-autoCraftingTable
-THIS IS A FORK OF CARPET AUTOCRAFTINGTABLE FOR MY TESTING PURPOSES. DO NOT USE THIS FORK. I HAVE ABSOLUTELY NO IDEA WHAT I AM DOING SO DON'T LOOK TO ME.
+# carpet-autoCraftingTable
+autoCraftingTable extension for carpet-mod. Implementation based on Skyrising's implementation for autoCraftingTable for QuickCarpet - implemnted here as an extension for fabric-carpet mod.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,5 +32,8 @@
   },
   "suggests": {
     "flamingo": "*"
+  },
+  "custom": {
+    "modmenu:parent": "carpet"
   }
 }


### PR DESCRIPTION
Changed fabric.mod.json to make it so that carpet autocraftingtable displays as a sub-part of carpet in modmenu, as Carpet TIS Additions has already done.