### PR TITLE
Helga - Fixed Fletching & Smiting table acting like Auto Crafting Table

### DIFF
--- a/src/main/java/carpet_autocraftingtable/mixins/CraftingTableBlockMixin.java
+++ b/src/main/java/carpet_autocraftingtable/mixins/CraftingTableBlockMixin.java
@@ -2,10 +2,7 @@ package carpet_autocraftingtable.mixins;
 
 import carpet.CarpetSettings;
 import carpet_autocraftingtable.AutoCraftingTableSettings;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockEntityProvider;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.CraftingTableBlock;
+import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.screen.NamedScreenHandlerFactory;
 import net.minecraft.entity.player.PlayerEntity;
@@ -38,7 +35,7 @@ public class CraftingTableBlockMixin extends Block implements BlockEntityProvide
     @Override
     public BlockEntity createBlockEntity(BlockPos pos, BlockState state)
     {
-        return AutoCraftingTableSettings.autoCraftingTable ? new CraftingTableBlockEntity(pos, state) : null;
+        return AutoCraftingTableSettings.autoCraftingTable ? (state.isOf(Blocks.CRAFTING_TABLE) ? new CraftingTableBlockEntity(pos, state) : null) : null;
     }
 
     @Inject(method = "onUse", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/carpet_autocraftingtable/mixins/CraftingTableBlockMixin.java
+++ b/src/main/java/carpet_autocraftingtable/mixins/CraftingTableBlockMixin.java
@@ -2,7 +2,10 @@ package carpet_autocraftingtable.mixins;
 
 import carpet.CarpetSettings;
 import carpet_autocraftingtable.AutoCraftingTableSettings;
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockEntityProvider;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.CraftingTableBlock;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.screen.NamedScreenHandlerFactory;
 import net.minecraft.entity.player.PlayerEntity;

--- a/src/main/java/carpet_autocraftingtable/mixins/CraftingTableBlockMixin.java
+++ b/src/main/java/carpet_autocraftingtable/mixins/CraftingTableBlockMixin.java
@@ -38,7 +38,7 @@ public class CraftingTableBlockMixin extends Block implements BlockEntityProvide
     @Override
     public BlockEntity createBlockEntity(BlockPos pos, BlockState state)
     {
-        return AutoCraftingTableSettings.autoCraftingTable ? (state.isOf(Blocks.CRAFTING_TABLE) ? new CraftingTableBlockEntity(pos, state) : null) : null;
+        return (AutoCraftingTableSettings.autoCraftingTable && state.isOf(Blocks.CRAFTING_TABLE) ? new CraftingTableBlockEntity(pos, state) : null;
     }
 
     @Inject(method = "onUse", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
Fletching Tables & Smitching tables both extend the crafting table. If you stick a hopper to them, you are able to use them as auto crafting tables. This became an issue in a villager trading system using Fletching Tables since making them auto crafting tables also adds the great benefit of making them immovable. 
We now check if its a crafting table before adding a block entity to it.