### PR TITLE
Distance check fix for crafting table

### DIFF
--- a/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
+++ b/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
@@ -118,4 +118,9 @@ public class AutoCraftingTableContainer extends CraftingScreenHandler {
             return super.onTakeItem(player, stack);
         }
     }
+
+   @Override
+   public boolean canUse(PlayerEntity player) {
+      return this.blockEntity.canPlayerUse(player);
+   }
 }

--- a/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
+++ b/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
@@ -165,8 +165,12 @@ public class CraftingTableBlockEntity extends LockableContainerBlockEntity imple
     }
 
     @Override
-    public boolean canPlayerUse(PlayerEntity var1) {
-        return true;
+    public boolean canPlayerUse(PlayerEntity player) {
+        if (this.world.getBlockEntity(this.pos) != this) {
+            return false;
+        } else {
+            return player.squaredDistanceTo((double)this.pos.getX() + 0.5D, (double)this.pos.getY() + 0.5D, (double)this.pos.getZ() + 0.5D) <= 64.0D;
+        }
     }
 
     @Override


### PR DESCRIPTION
The distance between a player and a chest/crafting table/etc is meant to be checked and the currently opened screen closed if the player goes out of range. This check is currently disabled with the autocrafting table and if a player moves out of range the crafting screen remains open. This causes issues like #18 where items can be duped using the still open screen.

 Pull request adds distance check back in.

