### PR TITLE
Spectator Bug & Explosion Bug fixes + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # carpet-autoCraftingTable
 autoCraftingTable extension for carpet-mod. Implementation based on Skyrising's implementation for autoCraftingTable for QuickCarpet - implemented here as an extension for fabric-carpet mod.
+
+When enabled, all crafting tables will contain block entites making them immovable. This means that items will also be stored inside the crafting table.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # carpet-autoCraftingTable
-autoCraftingTable extension for carpet-mod. Implementation based on Skyrising's implementation for autoCraftingTable for QuickCarpet - implemnted here as an extension for fabric-carpet mod.
+autoCraftingTable extension for carpet-mod. Implementation based on Skyrising's implementation for autoCraftingTable for QuickCarpet - implemented here as an extension for fabric-carpet mod.


### PR DESCRIPTION
Ported the fix for spectators not seeing the crafting table correctly from DeadlyMC/QuickCarpet114 by Skyrising

Made it so that crafting tables with items inside now drop their items when blown up, which I considered a bug.

Small changes to variable names to clean up the code a bit.

- Enjoy