### PR TITLE
Optimize recipe search by checking against last cached recipe before anything else

### DIFF
--- a/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
+++ b/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
@@ -188,7 +188,13 @@ public class CraftingTableBlockEntity extends LockableContainerBlockEntity imple
 
     private Optional<CraftingRecipe> getCurrentRecipe() {
         if (this.world == null) return Optional.empty();
-        Optional<CraftingRecipe> optionalRecipe = this.world.getRecipeManager().getFirstMatch(RecipeType.CRAFTING, craftingInventory, world);
+        Optional<CraftingRecipe> optionalRecipe;
+        if ((optionalRecipe = Optional.ofNullable((CraftingRecipe) getLastRecipe())).isPresent()) {
+            if (RecipeType.CRAFTING.match(optionalRecipe.get(), world, craftingInventory).isPresent()) {
+                return optionalRecipe;
+            }
+        }
+        optionalRecipe = this.world.getRecipeManager().getFirstMatch(RecipeType.CRAFTING, craftingInventory, world);
         optionalRecipe.ifPresent(this::setLastRecipe);
         return optionalRecipe;
     }


### PR DESCRIPTION
Firstly, auto crafting tables can cause a performance impact when used very often in large farms.
The main reason for this is due to the recipe lookup, which searches through all recipes.

So what I did was use the already existing last recipe, and attempt to check it first. This is a great performance boost since it drastically speeds up all the auto crafting tables in farms.

old = current state, new = with cache
![image](https://user-images.githubusercontent.com/28154542/151685384-236296cd-7c97-4ee9-a47d-28e04b1d8d4a.png)
Accidentally left the one with cache running for 10 seconds longer than the old one (after tick warp), either way, it shows the point.

![image](https://user-images.githubusercontent.com/28154542/151685420-da355e74-70b6-4231-b5e5-7582e8459802.png)

As you can also see, the extra match against the last cache added 62ms to the total checks which are nearly negligible. So adding 62ms to all auto crafting tables is worth it for the performance boost that this offers. 
