### PR TITLE
Fix lag caused by empty crafting table and Update to 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.11-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -15,10 +15,10 @@ targetCompatibility = JavaVersion.VERSION_17
 archivesBaseName = project.archives_base_name
 version = project.minecraft_version+'-'+project.mod_version
 group = project.maven_group
-minecraft.refmapName = "carpet-autocraftingtable-refmap.json"
+//minecraft.refmapName = "carpet-autocraftingtable-refmap.json"
 
 loom {
-	accessWidener = file("src/main/resources/act.accesswidener")
+	accessWidenerPath = file('src/main/resources/act.accesswidener')
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use or https://modmuss50.me/fabric.html
-	minecraft_version=1.18
-	yarn_mappings=1.18+build.1
-	loader_version=0.11.6
+	minecraft_version=1.18.2
+	yarn_mappings=1.18.2+build.2
+	loader_version=0.13.3
 	# check available versions on maven for the given minecraft version you are using
-	carpet_core_version=1.4.56+v211130
+	carpet_core_version=1.4.69+v220331
 
 # Mod Properties
 	mod_version = 1.4.56

--- a/src/main/java/carpet_autocraftingtable/AutoCraftingTable.java
+++ b/src/main/java/carpet_autocraftingtable/AutoCraftingTable.java
@@ -12,7 +12,6 @@ public class AutoCraftingTable implements CarpetExtension
 
     @Override
     public void onGameStarted() {
-        CraftingTableBlockEntity.init();
         // let's /carpet handle our few simple settings
         CarpetServer.settingsManager.parseSettingsClass(AutoCraftingTableSettings.class);
     }

--- a/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
+++ b/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
@@ -102,51 +102,52 @@ public class AutoCraftingTableContainer extends AbstractRecipeScreenHandler<Craf
     }
 
     @Override
-    public ItemStack transferSlot(PlayerEntity player, int slotIndex) {
-        ItemStack itemStack = ItemStack.EMPTY;
-        Slot slot = this.slots.get(slotIndex);
+    public ItemStack transferSlot(PlayerEntity player, int index) {
+        ItemStack remainderResultStack = ItemStack.EMPTY;
+        Slot slot = this.slots.get(index);
         if (slot.hasStack()) {
-            ItemStack slotStack = slot.getStack();
-            itemStack = slotStack.copy();
-            if (slotIndex == 0) {
-                ItemStack before = this.blockEntity.getStack(0).copy();
-                ItemStack current = before.copy();
-                if (!this.insertItem(current, 10, 46, true)) return ItemStack.EMPTY;
-                this.blockEntity.removeStack(0, before.getCount() - current.getCount());
-                if(player instanceof ServerPlayerEntity && blockEntity.getLastRecipe() != null) { // this sets recipe in container
-                    if (!blockEntity.shouldCraftRecipe(player.world, (ServerPlayerEntity) player, blockEntity.getLastRecipe())) {
+            ItemStack original = slot.getStack();
+            ItemStack resultStack = original.copy();
+            remainderResultStack = resultStack.copy();
+            if (index == 0) {
+                if (!this.insertItem(resultStack, 10, 46, true)) return ItemStack.EMPTY;
+                this.blockEntity.removeStack(index, original.getCount() - resultStack.getCount());
+                // this sets recipe in container
+                if(
+                    player instanceof ServerPlayerEntity
+                    && blockEntity.getLastRecipe() != null
+                    && !blockEntity.shouldCraftRecipe(player.world, (ServerPlayerEntity) player, blockEntity.getLastRecipe())
+                ) {
                         return ItemStack.EMPTY;
-                    }
                 }
-                slots.get(0).onQuickTransfer(current, before); // calls onCrafted if different
-                return this.blockEntity.getStack(0);
-            } else if (slotIndex >= 10 && slotIndex < 46) {
-                if (!this.insertItem(slotStack, 1, 10, false)) {
-                    if (slotIndex < 37) {
-                        if (!this.insertItem(slotStack, 37, 46, false)) {
+                slots.get(0).onQuickTransfer(resultStack, original); // calls onCrafted if different
+            } else if (index >= 10 && index < 46) {
+                if (!this.insertItem(resultStack, 1, 10, false)) {
+                    if (index < 37) {
+                        if (!this.insertItem(resultStack, 37, 46, false)) {
                             return ItemStack.EMPTY;
                         }
-                    } else if (!this.insertItem(slotStack, 10, 37, false)) {
+                    } else if (!this.insertItem(resultStack, 10, 37, false)) {
                         return ItemStack.EMPTY;
                     }
                 }
-            } else if (!this.insertItem(slotStack, 10, 46, false)) {
+            } else if (!this.insertItem(resultStack, 10, 46, false)) {
                 return ItemStack.EMPTY;
             }
 
-            if (slotStack.isEmpty()) {
+            if (resultStack.isEmpty()) {
                 slot.setStack(ItemStack.EMPTY);
             } else {
                 slot.markDirty();
             }
 
-            if (slotStack.getCount() == itemStack.getCount()) {
+            if (resultStack.getCount() == remainderResultStack.getCount()) {
                 return ItemStack.EMPTY;
             }
 
-            slot.onTakeItem(player, slotStack);
+            slot.onTakeItem(player, resultStack);
         }
-        return itemStack;
+        return remainderResultStack;
     }
 
     public void close(PlayerEntity player) {

--- a/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
+++ b/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
@@ -1,18 +1,18 @@
 package carpet_autocraftingtable;
 
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeMatcher;
+import net.minecraft.recipe.RecipeUnlocker;
 import net.minecraft.recipe.book.RecipeBookCategory;
 import net.minecraft.screen.AbstractRecipeScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.slot.Slot;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.inventory.Inventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.RecipeUnlocker;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -101,22 +101,48 @@ public class AutoCraftingTableContainer extends AbstractRecipeScreenHandler<Craf
         }
     }
 
+    /**
+     * Pretty much Ctrl + C and Ctrl + V from vanilla crafting table. except from the slot 0 part.
+     * Before this change it was triggering the infinite loop. in ScreenHandler.internalOnSlotClick() Quick Transfer
+     */
     @Override
-    public ItemStack transferSlot(PlayerEntity player, int slot) {
-        if (slot == 0) {
-            ItemStack before = this.blockEntity.getStack(0).copy();
-            ItemStack current = before.copy();
-            if (!this.insertItem(current, 10, 46, true)) return ItemStack.EMPTY;
-            this.blockEntity.removeStack(0, before.getCount() - current.getCount());
-            if(player instanceof ServerPlayerEntity && blockEntity.getLastRecipe() != null) { // this sets recipe in container
-                if (!blockEntity.shouldCraftRecipe(player.world, (ServerPlayerEntity) player, blockEntity.getLastRecipe())) {
+    public ItemStack transferSlot(PlayerEntity player, int slotIndex) {
+        ItemStack itemStack = ItemStack.EMPTY;
+        Slot slot = this.slots.get(slotIndex);
+        if (slot.hasStack()){
+            ItemStack slotStack = slot.getStack();
+            if (slotIndex == 0) {
+                ItemStack before = this.blockEntity.getStack(0).copy();
+                ItemStack current = before.copy();
+                if (!this.insertItem(current, 10, 46, true))
                     return ItemStack.EMPTY;
+                this.blockEntity.removeStack(0, before.getCount() - current.getCount());
+                if(player instanceof ServerPlayerEntity && blockEntity.getLastRecipe() != null) { // this sets recipe in container
+                    if (!blockEntity.shouldCraftRecipe(player.world, (ServerPlayerEntity) player, blockEntity.getLastRecipe())) {
+                        return ItemStack.EMPTY;
+                    }
                 }
+                slots.get(0).onQuickTransfer(current, before); // calls onCrafted if different
+            } else if (slotIndex >= 10 && slotIndex < 46
+                ? !this.insertItem(slotStack, 1, 10, false)
+                    && (slotIndex < 37
+                        ? !this.insertItem(slotStack, 37, 46, false)
+                        : !this.insertItem(slotStack, 10, 37, false))
+                : !this.insertItem(slotStack, 10, 46, false)
+            ) {
+                return ItemStack.EMPTY;
             }
-            slots.get(0).onQuickTransfer(current, before); // calls onCrafted if different
-            return this.blockEntity.getStack(0);
+            if (slotStack.isEmpty()) {
+                slot.setStack(ItemStack.EMPTY);
+            } else {
+                slot.markDirty();
+            }
+            if (slotStack.getCount() == itemStack.getCount()) {
+                return ItemStack.EMPTY;
+            }
+            slot.onTakeItem(player, slotStack);
         }
-        return super.transferSlot(player, slot);
+        return itemStack;
     }
 
     public void close(PlayerEntity player) {

--- a/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
+++ b/src/main/java/carpet_autocraftingtable/AutoCraftingTableContainer.java
@@ -102,21 +102,51 @@ public class AutoCraftingTableContainer extends AbstractRecipeScreenHandler<Craf
     }
 
     @Override
-    public ItemStack transferSlot(PlayerEntity player, int slot) {
-        if (slot == 0) {
-            ItemStack before = this.blockEntity.getStack(0).copy();
-            ItemStack current = before.copy();
-            if (!this.insertItem(current, 10, 46, true)) return ItemStack.EMPTY;
-            this.blockEntity.removeStack(0, before.getCount() - current.getCount());
-            if(player instanceof ServerPlayerEntity && blockEntity.getLastRecipe() != null) { // this sets recipe in container
-                if (!blockEntity.shouldCraftRecipe(player.world, (ServerPlayerEntity) player, blockEntity.getLastRecipe())) {
-                    return ItemStack.EMPTY;
+    public ItemStack transferSlot(PlayerEntity player, int slotIndex) {
+        ItemStack itemStack = ItemStack.EMPTY;
+        Slot slot = this.slots.get(slotIndex);
+        if (slot.hasStack()) {
+            ItemStack slotStack = slot.getStack();
+            itemStack = slotStack.copy();
+            if (slotIndex == 0) {
+                ItemStack before = this.blockEntity.getStack(0).copy();
+                ItemStack current = before.copy();
+                if (!this.insertItem(current, 10, 46, true)) return ItemStack.EMPTY;
+                this.blockEntity.removeStack(0, before.getCount() - current.getCount());
+                if(player instanceof ServerPlayerEntity && blockEntity.getLastRecipe() != null) { // this sets recipe in container
+                    if (!blockEntity.shouldCraftRecipe(player.world, (ServerPlayerEntity) player, blockEntity.getLastRecipe())) {
+                        return ItemStack.EMPTY;
+                    }
                 }
+                slots.get(0).onQuickTransfer(current, before); // calls onCrafted if different
+                return this.blockEntity.getStack(0);
+            } else if (slotIndex >= 10 && slotIndex < 46) {
+                if (!this.insertItem(slotStack, 1, 10, false)) {
+                    if (slotIndex < 37) {
+                        if (!this.insertItem(slotStack, 37, 46, false)) {
+                            return ItemStack.EMPTY;
+                        }
+                    } else if (!this.insertItem(slotStack, 10, 37, false)) {
+                        return ItemStack.EMPTY;
+                    }
+                }
+            } else if (!this.insertItem(slotStack, 10, 46, false)) {
+                return ItemStack.EMPTY;
             }
-            slots.get(0).onQuickTransfer(current, before); // calls onCrafted if different
-            return this.blockEntity.getStack(0);
+
+            if (slotStack.isEmpty()) {
+                slot.setStack(ItemStack.EMPTY);
+            } else {
+                slot.markDirty();
+            }
+
+            if (slotStack.getCount() == itemStack.getCount()) {
+                return ItemStack.EMPTY;
+            }
+
+            slot.onTakeItem(player, slotStack);
         }
-        return super.transferSlot(player, slot);
+        return itemStack;
     }
 
     public void close(PlayerEntity player) {

--- a/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
+++ b/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
@@ -160,7 +160,7 @@ public class CraftingTableBlockEntity extends LockableContainerBlockEntity imple
 
     @Override
     public boolean canPlayerUse(PlayerEntity player) {
-        return player.getBlockPos().getSquaredDistance(this.pos,false) <= 64.0D;
+        return player.getBlockPos().getSquaredDistance(this.pos) <= 64.0D;
     }
 
     @Override
@@ -199,7 +199,7 @@ public class CraftingTableBlockEntity extends LockableContainerBlockEntity imple
     private ItemStack craft() {
         if (this.world == null) return ItemStack.EMPTY;
         Optional<CraftingRecipe> optionalRecipe = getCurrentRecipe();
-        if (!optionalRecipe.isPresent()) return ItemStack.EMPTY;
+        if (optionalRecipe.isEmpty()) return ItemStack.EMPTY;
         CraftingRecipe recipe = optionalRecipe.get();
         ItemStack result = recipe.craft(craftingInventory);
         DefaultedList<ItemStack> remaining = world.getRecipeManager().getRemainingStacks(RecipeType.CRAFTING, craftingInventory, world);

--- a/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
+++ b/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
@@ -184,7 +184,8 @@ public class CraftingTableBlockEntity extends LockableContainerBlockEntity imple
     }
 
     private Optional<CraftingRecipe> getCurrentRecipe() {
-        if (this.world == null) return Optional.empty();
+        // No need to find recipes if the inventory is empty. Cannot craft anything.
+        if (this.world == null || this.isEmpty()) return Optional.empty();
         Optional<CraftingRecipe> optionalRecipe;
         if ((optionalRecipe = Optional.ofNullable((CraftingRecipe) getLastRecipe())).isPresent()) {
             if (RecipeType.CRAFTING.match(optionalRecipe.get(), world, craftingInventory).isPresent()) {

--- a/src/main/java/carpet_autocraftingtable/mixins/BootStrapMixin.java
+++ b/src/main/java/carpet_autocraftingtable/mixins/BootStrapMixin.java
@@ -1,0 +1,23 @@
+package carpet_autocraftingtable.mixins;
+
+import carpet_autocraftingtable.CraftingTableBlockEntity;
+import net.minecraft.Bootstrap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Bootstrap.class)
+public class BootStrapMixin {
+	@Inject(
+		method="initialize",
+		at=@At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/util/registry/Registry;freezeRegistries()V",
+			shift = At.Shift.BEFORE
+		)
+	)
+	private static void registerTableBeforeRegistryFreeze(CallbackInfo ci) {
+		CraftingTableBlockEntity.init();
+	}
+}

--- a/src/main/resources/carpet-autocraftingtable.mixins.json
+++ b/src/main/resources/carpet-autocraftingtable.mixins.json
@@ -3,9 +3,10 @@
   "package": "carpet_autocraftingtable.mixins",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "CrashReport_noopMixin",
+    "BootStrapMixin",
     "CraftingInventoryMixin",
-    "CraftingTableBlockMixin"
+    "CraftingTableBlockMixin",
+    "CrashReport_noopMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Empty crafting tables sitting on hoppers were causing tremendous lag due to recipe manager being invoked every tick to search for empty recipes.  
Since crafting tables were empty, there's no need to check for recipes, we can exit early.  
Update to 1.18.2 while at it.
resolves #54 
fixes #6