### PR TITLE
Add polymer-reg-sync-manipulator to fix compat for clients with Fabric API but not this mod installed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,9 @@ repositories {
 	maven {
 		url 'https://masa.dy.fi/maven'
 	}
+	maven {
+		url 'https://maven.nucleoid.xyz'
+	}
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -28,6 +31,8 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "carpet:fabric-carpet:${project.minecraft_version}-${project.carpet_core_version}"
+
+	modImplementation include("eu.pb4:polymer-reg-sync-manipulator:0.5.7+1.20.1")
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
+++ b/src/main/java/carpet_autocraftingtable/CraftingTableBlockEntity.java
@@ -1,6 +1,7 @@
 package carpet_autocraftingtable;
 
 import carpet_autocraftingtable.mixins.CraftingInventoryMixin;
+import eu.pb4.polymer.rsm.api.RegistrySyncUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntityType;
@@ -55,7 +56,10 @@ public class CraftingTableBlockEntity extends LockableContainerBlockEntity imple
 
     private final CraftingInventory craftingInventory = new CraftingInventory(null, 3, 3);
 
-    public static void init() { } // registers BE type
+    public static void init() { // registers BE type
+        // Mark as server-only registry entry
+        RegistrySyncUtils.setServerEntry(Registries.BLOCK_ENTITY_TYPE, TYPE);
+    }
 
     @Override
     public void writeNbt(NbtCompound tag) {


### PR DESCRIPTION
According to https://github.com/gnembon/carpet-autoCraftingTable/issues/67#issuecomment-1586386652 this should fix the compatibility issue. I was having some trouble verifying that this worked so if someone who experienced the issue can check this it would be much appreciated.
Closes #67 